### PR TITLE
hard setting typescript to 2.3.2 to avoid incompatabilities with rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "5.2.0",
     "ts-node": "~2.0.0",
     "tslint": "^4.5.1",
-    "typescript": "^2.1.6",
+    "typescript": "2.3.2",
     "electron": "^1.6.6"
   }
 }


### PR DESCRIPTION
Updating package.json to hard setting typescript to 2.3.2 to avoid incompatabilities with rxjs.