### PR TITLE
fix(editor): editor resizing for window resize, md-tabs, etc

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -25,6 +25,8 @@
 | `registerLanguage` | `function()` | Registers a custom Language within the editor
 | `editorStyle` | `string` | Additional Styling applied to Editor Container
 | `theme` | `string` | Theme used to style the Editor
+| `automaticLayout` | `boolean` | Implemented via setInterval that constantly probes for the container's size. Defaults to false.
+| `layout` | `function()` | Instructs the editor to remeasure its container
 | `isElectronApp` | `function()` | Returns true or false based on if running in Electron
 
 
@@ -39,6 +41,7 @@ Example for HTML usage:
         flex 
         theme="vs" 
         language="sql"
+        automaticLayout="true"
         [(ngModel)]="model"
         (change)="callBackFunc()">
 </td-code-editor>

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,7 +41,7 @@ Example for HTML usage:
         flex 
         theme="vs" 
         language="sql"
-        automaticLayout="true"
+        automaticLayout
         [(ngModel)]="model"
         (change)="callBackFunc()">
 </td-code-editor>

--- a/src/code-editor/code-editor.component.spec.ts
+++ b/src/code-editor/code-editor.component.spec.ts
@@ -4,7 +4,7 @@ import {
   async,
   ComponentFixture,
 } from '@angular/core/testing';
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { TdCodeEditorComponent } from './';
 import { By } from '@angular/platform-browser';
 
@@ -17,6 +17,7 @@ describe('Component: App', () => {
     TestBed.configureTestingModule({
       declarations: [
         TdCodeEditorComponent,
+        TestMultipleEditorsComponent,
       ],
       imports: [
       ],
@@ -165,4 +166,67 @@ describe('Component: App', () => {
     })();
   });
 
+  it('should show multiple editors and set the editors values and retrieve that same values from editors', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestMultipleEditorsComponent);
+      let component: TestMultipleEditorsComponent = fixture.debugElement.componentInstance;
+      if (component.editor1.isElectronApp) {
+        component.editor1.setEditorNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+        component.editor2.setEditorNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+        component.editor3.setEditorNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+      }
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        component.editor1.onEditorInitialized.subscribe(() => {
+          component.editor1.value = 'SELECT * FROM foo;';
+          component.editor1.getValue().subscribe((value: string) => {
+            fixture.whenStable().then(() => {
+              fixture.detectChanges();
+              fixture.changeDetectorRef.detectChanges();
+              expect(value).toBe('SELECT * FROM foo;');
+
+              component.editor2.value = 'SELECT * FROM foo2;';
+              component.editor2.getValue().subscribe((value2: string) => {
+                fixture.whenStable().then(() => {
+                  fixture.detectChanges();
+                  fixture.changeDetectorRef.detectChanges();
+                  expect(value2).toBe('SELECT * FROM foo2;');
+
+                  component.editor3.value = 'SELECT * FROM foo3;';
+                  component.editor3.getValue().subscribe((value3: string) => {
+                    fixture.whenStable().then(() => {
+                      fixture.detectChanges();
+                      fixture.changeDetectorRef.detectChanges();
+                      expect(value3).toBe('SELECT * FROM foo3;');
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    })();
+  });
+
 });
+
+@Component({
+  template: `
+    <div>
+      <td-code-editor #editor1 automaticLayout="true" style="height: 200px" theme="vs" flex language="javascript"></td-code-editor>  
+    </div>
+    <div>
+      <td-code-editor #editor2 automaticLayout="true" style="height: 200px" theme="vs" flex language="HTML"></td-code-editor>  
+    </div>
+    <div>
+      <td-code-editor #editor3 automaticLayout="true" style="height: 200px" theme="vs" flex language="css"></td-code-editor>  
+    </div>`,
+})
+class TestMultipleEditorsComponent {
+  @ViewChild('editor1') editor1: TdCodeEditorComponent;
+  @ViewChild('editor2') editor2: TdCodeEditorComponent;
+  @ViewChild('editor3') editor3: TdCodeEditorComponent;
+}

--- a/src/code-editor/code-editor.component.spec.ts
+++ b/src/code-editor/code-editor.component.spec.ts
@@ -216,13 +216,13 @@ describe('Component: App', () => {
 @Component({
   template: `
     <div>
-      <td-code-editor #editor1 automaticLayout="true" style="height: 200px" theme="vs" flex language="javascript"></td-code-editor>  
+      <td-code-editor #editor1 automaticLayout style="height: 200px" theme="vs" flex language="javascript"></td-code-editor>  
     </div>
     <div>
-      <td-code-editor #editor2 automaticLayout="true" style="height: 200px" theme="vs" flex language="HTML"></td-code-editor>  
+      <td-code-editor #editor2 automaticLayout style="height: 200px" theme="vs" flex language="HTML"></td-code-editor>  
     </div>
     <div>
-      <td-code-editor #editor3 automaticLayout="true" style="height: 200px" theme="vs" flex language="css"></td-code-editor>  
+      <td-code-editor #editor3 automaticLayout style="height: 200px" theme="vs" flex language="css"></td-code-editor>  
     </div>`,
 })
 class TestMultipleEditorsComponent {

--- a/src/code-editor/code-editor.component.ts
+++ b/src/code-editor/code-editor.component.ts
@@ -310,10 +310,10 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
    * Implemented via setInterval that constantly probes for the container's size
    */
   @Input('automaticLayout')
-  set automaticLayout(automaticLayout: boolean) {
-    this._automaticLayout = automaticLayout;
+  set automaticLayout(automaticLayout: any) {
+    this._automaticLayout = automaticLayout !== '' ? (automaticLayout === 'true' || automaticLayout === true) : true;
   }
-  get automaticLayout(): boolean {
+  get automaticLayout(): any {
     return this._automaticLayout;
   }
 


### PR DESCRIPTION
Exposing automaticLayout method that via setInterval that constantly probes for the container's size. Also a layout() method that manually instructs the editor to remeasure its container

closes #11

Test Steps
-[ ] Checkout branch
-[ ] npm run build
-[ ] cd deploy/code-editor
-[ ] npm pack (prints out a tgz file created)
-[ ] pwd (prints out your < path > you are at)
-[ ] Go to Covalent repo
-[ ] rm -rf node_modules/`@covalent`/code-editor
-[ ] npm install < path > / < tgz file created >
-[ ] edit the demo for code-editor.component.html and add the following:
```html
    <md-tab-group>
      <md-tab label="app code">
        <td-code-editor automaticLayout="true" style="height: 200px" theme="vs" flex language="javascript" [(ngModel)]='frontEndJSCode' id="js"></td-code-editor>  
      </md-tab>
      <md-tab label="HTML">
        <td-code-editor automaticLayout="true" style="height: 200px" theme="vs" flex language="HTML" [(ngModel)]='frontEndHTMLCode' id="html"></td-code-editor>  
      </md-tab>
      <md-tab label="CSS">
        <td-code-editor #editor style="height: 200px" theme="vs" flex language="css" [(ngModel)]='frontEndCSSCode' id="css"></td-code-editor>  
      </md-tab>
    </md-tab-group>
    <button md-raised-button color="accent" (click)="editor.layout()" class="text-upper">SetLayout</button>
```
-[ ] npm run serve
-[ ] ng serve
-[ ] In browser go to: http://localhost:4200/#/components/code-editor
-[ ] See Tab group with Editors
-[ ] See Editor shows up in first two tabs and not last tab
-[ ] On last tab click SETLAYOUT button
-[ ] See Editor Show up