### PR TITLE
feat(editorOptions): Add Editor Options to Component

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,6 +26,7 @@
 | `editorStyle` | `string` | Additional Styling applied to Editor Container
 | `theme` | `string` | Theme used to style the Editor
 | `automaticLayout` | `boolean` | Implemented via setInterval that constantly probes for the container's size. Defaults to false.
+| `editorOptions` | `Object` | Editor Options Object of valid Configurations listed here: <a href="https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html">https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html</a>
 | `layout` | `function()` | Instructs the editor to remeasure its container
 | `isElectronApp` | `function()` | Returns true or false based on if running in Electron
 
@@ -42,6 +43,7 @@ Example for HTML usage:
         theme="vs" 
         language="sql"
         automaticLayout
+        [editorOptions]="{readOnly:true, fontSize:20}"
         [(ngModel)]="model"
         (change)="callBackFunc()">
 </td-code-editor>

--- a/src/platform/code-editor/code-editor.component.spec.ts
+++ b/src/platform/code-editor/code-editor.component.spec.ts
@@ -167,7 +167,7 @@ describe('Component: App', () => {
     })();
   });
 
-  it('should set the editor options', (done: DoneFn) => {
+  it('should set the editor options and retrieve them', (done: DoneFn) => {
     inject([], () => {
       let fixture: ComponentFixture<any> = TestBed.createComponent(TestEditorOptionsComponent);
       let component: TestEditorOptionsComponent = fixture.debugElement.componentInstance;

--- a/src/platform/code-editor/code-editor.component.spec.ts
+++ b/src/platform/code-editor/code-editor.component.spec.ts
@@ -18,6 +18,7 @@ describe('Component: App', () => {
       declarations: [
         TdCodeEditorComponent,
         TestMultipleEditorsComponent,
+        TestEditorOptionsComponent,
       ],
       imports: [
       ],
@@ -166,6 +167,24 @@ describe('Component: App', () => {
     })();
   });
 
+  it('should set the editor options', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestEditorOptionsComponent);
+      let component: TestEditorOptionsComponent = fixture.debugElement.componentInstance;
+      if (component.editor1.isElectronApp) {
+        component.editor1.setEditorNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+      }
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        component.editor1.onEditorInitialized.subscribe(() => {
+          expect(component.editor1.editorOptions.readOnly).toBe(true);
+          done();
+        });
+      });
+    })();
+  });
+
   it('should show multiple editors and set the editors values and retrieve that same values from editors', (done: DoneFn) => {
     inject([], () => {
       let fixture: ComponentFixture<any> = TestBed.createComponent(TestMultipleEditorsComponent);
@@ -229,4 +248,15 @@ class TestMultipleEditorsComponent {
   @ViewChild('editor1') editor1: TdCodeEditorComponent;
   @ViewChild('editor2') editor2: TdCodeEditorComponent;
   @ViewChild('editor3') editor3: TdCodeEditorComponent;
+}
+
+@Component({
+  template: `
+    <div>
+      <td-code-editor #editor1 [editorOptions]="{readOnly:true}" style="height: 200px" theme="vs" flex language="javascript"></td-code-editor>  
+    </div>
+`,
+})
+class TestEditorOptionsComponent {
+  @ViewChild('editor1') editor1: TdCodeEditorComponent;
 }

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -43,6 +43,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
   private _componentInitialized: boolean = false;
   private _fromEditor: boolean = false;
   private _automaticLayout: boolean = false;
+  private _editorOptions: any = {};
 
   @ViewChild('editorContainer') _editorContainer: ElementRef;
 
@@ -186,11 +187,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
             let currentValue: string = this._editor.getValue();
             this._editor.dispose();
             let myDiv: HTMLDivElement = this._editorContainer.nativeElement;
-            this._editor = monaco.editor.create(myDiv, {
+            this._editor = monaco.editor.create(myDiv, Object.assign({
                 value: currentValue,
                 language: language,
                 theme: this._theme,
-            });
+            }, this.editorOptions));
             this._editor.getModel().onDidChangeContent( (e: any) => {
                 this._fromEditor = true;
                 this.writeValue(this._editor.getValue());
@@ -269,11 +270,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
             let currentValue: string = this._editor.getValue();
             this._editor.dispose();
             let myDiv: HTMLDivElement = this._editorContainer.nativeElement;
-            this._editor = monaco.editor.create(myDiv, {
+            this._editor = monaco.editor.create(myDiv, Object.assign({
                 value: currentValue,
                 language: this._language,
                 theme: this._theme,
-            });
+            }, this.editorOptions));
             this._editor.getModel().onDidChangeContent( (e: any) => {
                 this._fromEditor = true;
                 this.writeValue(this._editor.getValue());
@@ -315,6 +316,19 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
   }
   get automaticLayout(): any {
     return this._automaticLayout;
+  }
+
+  /**
+   * editorOptions?: Object
+   * Options used on editor instantiation. Available options listed here:
+   * https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html
+   */
+  @Input('editorOptions')
+  set editorOptions(editorOptions: any) {
+      this._editorOptions = editorOptions;
+  }
+  get editorOptions(): any {
+    return this._editorOptions;
   }
 
   /**
@@ -381,11 +395,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                 self.process.browser = true;
 
                 require(['vs/editor/editor.main'], function() {
-                    editor = monaco.editor.create(document.getElementById('${this._editorInnerContainer}'), {
+                    editor = monaco.editor.create(document.getElementById('${this._editorInnerContainer}'), Object.assign({
                         value: value,
                         language: '${this.language}',
                         theme: '${this._theme}',
-                    });
+                    }, '${this.editorOptions}'));
                     editor.getModel().onDidChangeContent( (e)=> {
                         ipcRenderer.sendToHost("onEditorContentChange", editor.getValue());
                     });
@@ -409,11 +423,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                     editorDiv.style = data.style;
                     var currentValue = editor.getValue();
                     editor.dispose();
-                    editor = monaco.editor.create(document.getElementById('${this._editorInnerContainer}'), {
+                    editor = monaco.editor.create(document.getElementById('${this._editorInnerContainer}'), Object.assign({
                         value: currentValue,
                         language: data.language,
                         theme: data.theme,
-                    });
+                    }, '${this.editorOptions}'));
                 });
 
                 // set the options of the editor from what was sent from the mainview
@@ -426,11 +440,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                 ipcRenderer.on('setLanguage', function(event, data){
                     var currentValue = editor.getValue();
                     editor.dispose();
-                    editor = monaco.editor.create(document.getElementById('${this._editorInnerContainer}'), {
+                    editor = monaco.editor.create(document.getElementById('${this._editorInnerContainer}'), Object.assign({
                         value: currentValue,
                         language: data,
                         theme: theme,
-                    });
+                    }, '${this.editorOptions}'));
                     ipcRenderer.sendToHost("onEditorConfigurationChanged", '');
                     ipcRenderer.sendToHost("onEditorLanguageChanged", '');
                 });
@@ -585,12 +599,12 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
   private initMonaco(): void {
     let containerDiv: HTMLDivElement = this._editorContainer.nativeElement;
     containerDiv.id = this._editorInnerContainer;
-    this._editor = monaco.editor.create(containerDiv, {
+    this._editor = monaco.editor.create(containerDiv, Object.assign({
         value: this._value,
         language: this.language,
         theme: this._theme,
         automaticLayout: this._automaticLayout,
-    });
+    }, this.editorOptions));
     setTimeout(() => {
         this.onEditorInitialized.emit(undefined);
     });

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -399,7 +399,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                         value: value,
                         language: '${this.language}',
                         theme: '${this._theme}',
-                    }, '${this.editorOptions}'));
+                    }, ${JSON.stringify(this.editorOptions)}));
                     editor.getModel().onDidChangeContent( (e)=> {
                         ipcRenderer.sendToHost("onEditorContentChange", editor.getValue());
                     });
@@ -427,7 +427,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                         value: currentValue,
                         language: data.language,
                         theme: data.theme,
-                    }, '${this.editorOptions}'));
+                    }, ${JSON.stringify(this.editorOptions)}));
                 });
 
                 // set the options of the editor from what was sent from the mainview
@@ -444,7 +444,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                         value: currentValue,
                         language: data,
                         theme: theme,
-                    }, '${this.editorOptions}'));
+                    }, ${JSON.stringify(this.editorOptions)}));
                     ipcRenderer.sendToHost("onEditorConfigurationChanged", '');
                     ipcRenderer.sendToHost("onEditorLanguageChanged", '');
                 });


### PR DESCRIPTION
## Description
Add the ability to pass in a configuration object containing anything from here:
https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html

closes #15

#### Test Steps
- [x] Checkout branch
- [x] npm i
- [x] npm run build
- [x] cd deploy/platform/code-editor
- [x] npm pack (prints out a tgz file created)
- [x] pwd (prints out your < path > you are at)
- [x] Go to Covalent repo
- [x] rm -rf node_modules/`@covalent`/code-editor
- [x] npm install < path > / < tgz file created >
- [x] edit the demo for code-editor.component.html and change the <td-code-editor tag to the following:
```html
    <td-code-editor #editor class="editor" [editorOptions]="{readOnly:true, fontSize:20}" [theme]="editorTheme" flex [language]="editorLanguage" [(ngModel)]="editorVal"></td-code-editor>
```
- [x] ng serve
- [x] In browser go to: http://localhost:4200/#/components/code-editor
- [x] See the Editor with Bigger Text
- [x] See the Editor is readonly

#### Test Steps on every PR
- [x] `npm run test` passes
- [x] `ng lint` passes

#### Screenshot
![screen shot 2017-08-21 at 3 23 39 pm](https://user-images.githubusercontent.com/10502797/29540718-c3a5c186-8684-11e7-8aab-11eb3c62932f.png)

