### PR TITLE
feat(ng-packagr): Add Support for ng-packagr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/code-editor",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "private": false,
   "description": "Teradata Text and Code Editor built on Covalent and Angular Material",
   "keywords": [
@@ -97,6 +97,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "merge2": "1.0.2",
+    "ng-packagr": "2.0.0",
     "node-sass": "3.8.0",
     "protractor": "~5.1.0",
     "require-dir": "0.3.2",

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -1,41 +1,11 @@
 #!/bin/bash
 
-set -o errexit
-
-# Clear deploy/ so that we guarantee there are no stale artifacts.
-echo "Cleaning deploy/"
+echo 'Clean up'
 rm -rf ./deploy
 
-# Perform a build.
-gulp build
-echo "SASS compiled..."
-
-# Prepare for aot
-gulp prepare-aot
-echo "Preparing files for AoT build"
-
-# AoT compilation
-npm run aot
-echo "Compiled TS and generated *.metadata.json files..."
-
-# copy README.md into deploy
-cp -rf README.md deploy/platform/code-editor/
+./node_modules/.bin/ng-packagr -p ./src/platform/code-editor/ng-package.js
 
 # copy Monaco
 mkdir deploy/platform/code-editor/assets
 mkdir deploy/platform/code-editor/assets/monaco
 cp -rf node_modules/monaco-editor/min/* deploy/platform/code-editor/assets/monaco/
-
-# Clean source .ts files
-cd deploy/
-find . -name "*.ts" ! -name "*.d.ts" -type f -delete
-cd ..
-echo "Remove source .ts files so they arent published"
-
-# Inline the css and html into the component files.
-gulp inline-resource-files
-echo "Resources inlined..."
-
-# Bundle
-gulp rollup-code
-echo "Bundled..."

--- a/src/platform/code-editor/index.ts
+++ b/src/platform/code-editor/index.ts
@@ -1,2 +1,1 @@
-export { TdCodeEditorComponent } from './code-editor.component';
-export { CovalentCodeEditorModule } from './code-editor.module';
+export * from './public-api';

--- a/src/platform/code-editor/ng-package.js
+++ b/src/platform/code-editor/ng-package.js
@@ -1,0 +1,3 @@
+let ngPackageSettings = require('../ng-package-common.js');
+ngPackageSettings["dest"] = "../../../deploy/platform/code-editor"
+module.exports = ngPackageSettings;

--- a/src/platform/code-editor/package.json
+++ b/src/platform/code-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/code-editor",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "private": false,
   "description": "Teradata Text and Code Editor built on Covalent and Angular Material",
   "main": "./code-editor.umd.js",

--- a/src/platform/code-editor/public-api.ts
+++ b/src/platform/code-editor/public-api.ts
@@ -1,0 +1,2 @@
+export { TdCodeEditorComponent } from './code-editor.component';
+export { CovalentCodeEditorModule } from './code-editor.module';

--- a/src/platform/code-editor/tsconfig.json
+++ b/src/platform/code-editor/tsconfig.json
@@ -1,0 +1,16 @@
+// Configuration for IDEs only.
+{
+  "extends": "../../tsconfig.app.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@covalent/code-editor/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/src/platform/ng-package-common.js
+++ b/src/platform/ng-package-common.js
@@ -1,0 +1,9 @@
+module.exports =
+{
+  "lib": {
+    "entryFile": "index.ts",
+    "umdModuleIds": {
+      "@covalent/code-editor": "covalent.code-editor"
+    }
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "../node_modules/@types"
     ],
+    "paths": {
+      "@covalent/code-editor/*": ["./platform/code-editor/*"]
+    },
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "allowUnreachableCode": false,


### PR DESCRIPTION
## Description
Add Support for ng-packagr

### Test Steps
- [x] Checkout branch
- [x] npm install
- [x] npm run build
- [x] cd deploy/platform/code-editor
- [x] npm pack (prints out a tgz file created)
- [x] pwd (prints out your < path > you are at)
- [x] Go to Covalent repo
- [x] rm -rf node_modules/`@covalent`/code-editor
- [x] npm install < path > / < tgz file created >
- [x] ng serve --aot
- [x] In browser go to: http://localhost:4200/#/components/code-editor
- [x] See Editor running
- [x] Use some of the functionality and see works

#### Test Steps on every PR
- [x] `npm run test` passes
- [x] `ng lint` passes