### PR TITLE
fix(): Fix for change event called before ngModel propogates value

### DIFF
--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -108,8 +108,8 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                     this._webview.send('setEditorContent', value);
                 }
                 this.onEditorValueChange.emit(undefined);
-                this.onChange.emit(undefined);
                 this.propagateChange(this._value);
+                this.onChange.emit(undefined);
                 this._fromEditor = false;
             } else {
                 // Editor is not loaded yet, try again in half a second
@@ -124,8 +124,8 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                     this._editor.setValue(value);
                 }
                 this.onEditorValueChange.emit(undefined);
-                this.onChange.emit(undefined);
                 this.propagateChange(this._value);
+                this.onChange.emit(undefined);
                 this._fromEditor = false;
                 this.zone.run(() => this._value = value);
             }


### PR DESCRIPTION
### Description

The change event was being called before ngModel  was propagating the change.  Switched order of calls being made.

#### Test Steps
- [ ] `ng serve`
- [ ] Edit app.component.html and change to:
```
<td-code-editor [(ngModel)]="code" (change)="onChange()"></td-code-editor>
```
- [ ] Edit app.component.ts and change to:
```
import { Component } from '@angular/core';

@Component({
  selector: 'docs-covalent',
  templateUrl: './app.component.html',
  styleUrls: ['./app.component.scss'],
})
export class DocsAppComponent {

  code: string = 'foo';

  onChange(): void {
    console.log("onChange: " + this.code);
  }
}
```
- [ ] Go to http://localhost:4200
- [ ] Open Console in browser
- [ ] Type into editor
- [ ] See correctly outputs what you type into Console

closes https://github.com/Teradata/covalent-code-editor/issues/33