### PR TITLE
feat(): Add ability to update Editor Options after component is initalized

### DIFF
--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -325,6 +325,14 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
   @Input('editorOptions')
   set editorOptions(editorOptions: any) {
       this._editorOptions = editorOptions;
+      if (this._componentInitialized) {
+        if (this._webview) {
+          this._webview.send('setEditorOptions', editorOptions);
+        } else {
+          this._editor.updateOptions(editorOptions);
+          this.onEditorConfigurationChanged.emit(undefined);
+        }
+      }
   }
   get editorOptions(): any {
     return this._editorOptions;


### PR DESCRIPTION
## Description
Added call to setEditorOptions when setter for editorOptions is called
closes #40 

### What's included?
- modified:   src/platform/code-editor/code-editor.component.ts

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `checkout branch`
- [ ] Edit src/app/app.component.html
- [ ] Change content of file to:
```
<td-code-editor [editorOptions]="{readOnly:true}" #myeditor></td-code-editor>
<button (click)="myeditor.editorOptions = {readOnly:false}">clickme</button>
```
- [ ] ng serve
- [ ] go to http://localhost:4200
- [ ] See Editor is readonly, can't type in it
- [ ] Click the "clickme" button
- [ ] See editor is no longer readonly and can type in it



