### PR TITLE
Use ng cli instead of ng-packagr

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -110,14 +110,22 @@
             "protractorConfig": "./protractor.conf.js",
             "devServerTarget": "covalent:serve"
           }
-        },
-        "lint": {
-          "builder": "@angular-devkit/build-angular:tslint",
+        }
+      }
+    },
+    "covalent-code-editor": {
+      "root": "src",
+      "sourceRoot": "src",
+      "projectType": "library",
+      "prefix": "lib",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-ng-packagr:build",
           "options": {
-            "tsConfig": [],
-            "exclude": []
+            "project": "src/platform/code-editor/ng-package.js"
           }
         }
+
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.11.0",
+    "@angular-devkit/build-ng-packagr": "^0.11.3",
     "@angular/cli": "^7.1.2",
     "@angular/compiler-cli": "^7.1.2",
     "@types/hammerjs": "^2.0.30",

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -3,9 +3,8 @@
 echo 'Clean up'
 rm -rf ./deploy
 
-./node_modules/.bin/ng-packagr -p ./src/platform/code-editor/ng-package.js
+./node_modules/@angular/cli/bin/ng build covalent-code-editor
 
 # copy Monaco
-mkdir deploy/platform/code-editor/assets
-mkdir deploy/platform/code-editor/assets/monaco
+mkdir -p deploy/platform/code-editor/assets/monaco
 cp -rf node_modules/monaco-editor/min/* deploy/platform/code-editor/assets/monaco/

--- a/src/platform/code-editor/code-editor.component.spec.ts
+++ b/src/platform/code-editor/code-editor.component.spec.ts
@@ -267,7 +267,7 @@ describe('Component: App', () => {
 
           component.exitFullScreenEditor();
 
-          expect(document.webkitExitFullscreen).toBeDefined();
+          expect((<any>document).webkitExitFullscreen).toBeDefined();
           done();
         });
       });
@@ -292,7 +292,7 @@ describe('Component: App', () => {
 
           component.showFullScreenEditor();
 
-          expect(containerDiv.webkitRequestFullscreen).toHaveBeenCalled();
+          expect((<any>containerDiv).webkitRequestFullscreen).toHaveBeenCalled();
           done();
         });
       });

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -608,7 +608,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
        // Chrome
       'requestFullscreen': () => codeEditorElement.requestFullscreen(),
        // Safari
-      'webkitRequestFullscreen': () => codeEditorElement.webkitRequestFullscreen(),
+      'webkitRequestFullscreen': () => (<any>codeEditorElement).webkitRequestFullscreen(),
        // IE
       'msRequestFullscreen': () => (<any>codeEditorElement).msRequestFullscreen(),
        // Firefox
@@ -630,7 +630,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
       // Chrome
       'exitFullscreen': () => document.exitFullscreen(),
       // Safari
-      'webkitExitFullscreen': () => document.webkitExitFullscreen(),
+      'webkitExitFullscreen': () => (<any>document).webkitExitFullscreen(),
       // Firefox
       'mozCancelFullScreen': () => (<any>document).mozCancelFullScreen(),
       // IE


### PR DESCRIPTION
## Description

Use ng cli instead of ng-packagr
Fixes #50 

### What's included?

Fixed linting errors that made it through.
Removed empty e2e linting that broke `ng lint`

#### Test Steps
- [ ] `npm install`
- [ ] `npm run build`
- [ ] Check it builds correctly.
