### PR TITLE
fix(ng-model): Do not set value to an outdated value

### DIFF
--- a/src/platform/code-editor/code-editor.component.spec.ts
+++ b/src/platform/code-editor/code-editor.component.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/core/testing';
 import { Component, ViewChild } from '@angular/core';
 import { TdCodeEditorComponent } from './';
+import { FormsModule } from '@angular/forms';
 
 declare var electron: any;
 declare const process: any;
@@ -26,8 +27,11 @@ describe('Component: App', () => {
         TdCodeEditorComponent,
         TestMultipleEditorsComponent,
         TestEditorOptionsComponent,
+        TestTwoWayBindingWithValueComponent,
+        TestTwoWayBindingWithNgModelComponent,
       ],
       imports: [
+        FormsModule,
       ],
     });
     TestBed.compileComponents();
@@ -293,6 +297,64 @@ describe('Component: App', () => {
     })();
   });
 
+  it('should work with 2 way binding via value', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestTwoWayBindingWithValueComponent);
+      let component: TestTwoWayBindingWithValueComponent = fixture.debugElement.componentInstance;
+      if (component.editor.isElectronApp) {
+        component.editor.setEditorNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+      }
+      const newSampleCode: string = 'const val = 2;';
+      component.sampleCode = newSampleCode;
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        component.editor.onEditorInitialized.subscribe(() => {
+          fixture.changeDetectorRef.detectChanges();
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            setTimeout(() => {
+              component.editor.getValue().subscribe((value: string) => {
+                expect(component.sampleCode).toBe(newSampleCode);
+                expect(value).toBe(newSampleCode);
+                done();
+              });
+            }, 1000); // wait for timeouts
+          });
+        });
+      });
+    })();
+  });
+
+
+  it('should work with 2 way binding via ngModel', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestTwoWayBindingWithNgModelComponent);
+      let component: TestTwoWayBindingWithNgModelComponent = fixture.debugElement.componentInstance;
+      if (component.editor.isElectronApp) {
+        component.editor.setEditorNodeModuleDirOverride(electron.remote.process.env.NODE_MODULE_DIR);
+      }
+      const newSampleCode: string = 'const val = 2;';
+      component.sampleCode = newSampleCode;
+      fixture.changeDetectorRef.detectChanges();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        component.editor.onEditorInitialized.subscribe(() => {
+          fixture.changeDetectorRef.detectChanges();
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            setTimeout(() => {
+              component.editor.getValue().subscribe((value: string) => {
+                expect(component.sampleCode).toBe(newSampleCode);
+                expect(value).toBe(newSampleCode);
+                done();
+              });
+            }, 1000); // wait for timeouts
+          });
+        });
+      });
+    })();
+  });
 });
 
 @Component({
@@ -322,4 +384,40 @@ class TestMultipleEditorsComponent {
 })
 class TestEditorOptionsComponent {
   @ViewChild('editor1') editor1: TdCodeEditorComponent;
+}
+
+@Component({
+  template: `
+    <div>
+      <td-code-editor
+        #editor
+        style="height: 200px"
+        language="javascript"
+        [(value)]="sampleCode"
+      >
+      </td-code-editor>
+    </div>
+  `,
+})
+class TestTwoWayBindingWithValueComponent {
+  @ViewChild('editor') editor: TdCodeEditorComponent;
+  sampleCode: string = `const val = 1;`;
+}
+
+@Component({
+  template: `
+    <div>
+      <td-code-editor
+        #editor
+        style="height: 200px"
+        language="javascript"
+        [(ngModel)]="sampleCode"
+      >
+      </td-code-editor>
+    </div>
+  `,
+})
+class TestTwoWayBindingWithNgModelComponent {
+  @ViewChild('editor') editor: TdCodeEditorComponent;
+  sampleCode: string = `const val = 1;`;
 }

--- a/src/platform/code-editor/code-editor.component.spec.ts
+++ b/src/platform/code-editor/code-editor.component.spec.ts
@@ -326,7 +326,6 @@ describe('Component: App', () => {
     })();
   });
 
-
   it('should work with 2 way binding via ngModel', (done: DoneFn) => {
     inject([], () => {
       let fixture: ComponentFixture<any> = TestBed.createComponent(TestTwoWayBindingWithNgModelComponent);

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -614,6 +614,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
         this._webview.addEventListener('ipc-message', (event: any) => {
             if (event.channel === 'editorContent') {
               this._fromEditor = true;
+              this.writeValue(event.args[0]);
               this._subject.next(this._value);
               this._subject.complete();
               this._subject = new Subject();

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, OnInit, AfterViewInit,
-  ViewChild, ElementRef, forwardRef, NgZone, ChangeDetectorRef } from '@angular/core';
+  ViewChild, ElementRef, forwardRef, NgZone, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Observable, Subject } from 'rxjs';
 
@@ -27,7 +27,7 @@ declare const process: any;
     multi: true,
   }],
 })
-export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValueAccessor {
+export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValueAccessor, OnDestroy {
 
   private _editorStyle: string = 'width:100%;height:100%;border:1px solid grey;';
   private _appPath: string = '';
@@ -678,6 +678,10 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
     }
   }
 
+  ngOnDestroy(): void {
+    this._changeDetectorRef.detach();
+  }
+
   /**
    * waitForMonaco method Returns promise that will be fulfilled when monaco is available
    */
@@ -787,7 +791,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
               let result: any = await origMethod.apply(that._editor, args);
               // since running javascript code manually need to force Angular to detect changes
               setTimeout(() => {
-                that.zone.run(() => that._changeDetectorRef.detectChanges());
+                that.zone.run(() => {
+                    if (!that._changeDetectorRef['destroyed']) {
+                        that._changeDetectorRef.detectChanges();
+                    }
+                });
               });
               return result;
             }

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -48,6 +48,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
   private _isFullScreen: boolean = false;
   private _keycode: any;
   private _setValueTimeout: any;
+  private initialContentChange: boolean = true;
 
   @ViewChild('editorContainer') _editorContainer: ElementRef;
 
@@ -621,6 +622,10 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
             } else if (event.channel === 'onEditorContentChange') {
               this._fromEditor = true;
               this.writeValue(event.args[0]);
+              if (this.initialContentChange) {
+                this.initialContentChange = false;
+                this.layout();
+            }
             } else if (event.channel === 'onEditorInitialized') {
               this._componentInitialized = true;
               this._editorProxy = this.wrapEditorCalls(this._editor);
@@ -829,11 +834,15 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
     this._editor.getModel().onDidChangeContent( (e: any) => {
         this._fromEditor = true;
         this.writeValue(this._editor.getValue());
+        if (this.initialContentChange) {
+            this.initialContentChange = false;
+            this.layout();
+        }
     });
     // need to manually resize the editor any time the window size
     // changes. See: https://github.com/Microsoft/monaco-editor/issues/28
     window.addEventListener('resize', () => {
-        this._editor.layout();
+        this.layout();
     });
     this.addFullScreenModeCommand();
   }

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -144,6 +144,10 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
               }, 500);
             }
         }
+    } else {
+        this._setValueTimeout = setTimeout(() => {
+            this.value = value;
+        }, 500);
     }
   }
 
@@ -155,7 +159,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
    * Implemented as part of ControlValueAccessor.
    */
   writeValue(value: any): void {
-    this.value = value;
+    // do not write if null or undefined
+    // tslint:disable-next-line
+    if ( value != undefined) {
+      this.value = value;
+    }
   }
   registerOnChange(fn: any): void {
     this.propagateChange = fn;
@@ -606,7 +614,6 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
         this._webview.addEventListener('ipc-message', (event: any) => {
             if (event.channel === 'editorContent') {
               this._fromEditor = true;
-              this.writeValue(event.args[0]);
               this._subject.next(this._value);
               this._subject.complete();
               this._subject = new Subject();
@@ -614,6 +621,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
               this._fromEditor = true;
               this.writeValue(event.args[0]);
             } else if (event.channel === 'onEditorInitialized') {
+              this._componentInitialized = true;
               this._editorProxy = this.wrapEditorCalls(this._editor);
               this.onEditorInitialized.emit(this._editorProxy);
             } else if (event.channel === 'onEditorConfigurationChanged') {
@@ -626,7 +634,6 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
         // append the webview to the DOM
         this._editorContainer.nativeElement.appendChild(this._webview);
     }
-    this._componentInitialized = true;
   }
 
   /**
@@ -806,6 +813,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
     }, this.editorOptions));
     setTimeout(() => {
         this._editorProxy = this.wrapEditorCalls(this._editor);
+        this._componentInitialized = true;
         this.onEditorInitialized.emit(this._editorProxy);
     });
     this._editor.getModel().onDidChangeContent( (e: any) => {

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -792,6 +792,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
               // since running javascript code manually need to force Angular to detect changes
               setTimeout(() => {
                 that.zone.run(() => {
+                    // tslint:disable-next-line
                     if (!that._changeDetectorRef['destroyed']) {
                         that._changeDetectorRef.detectChanges();
                     }

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -47,6 +47,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
   private _editorOptions: any = {};
   private _isFullScreen: boolean = false;
   private _keycode: any;
+  private _setValueTimeout: any;
 
   @ViewChild('editorContainer') _editorContainer: ElementRef;
 
@@ -103,6 +104,10 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
    */
   @Input('value')
   set value(value: string) {
+    // Clear any timeout that might overwrite this value set in the future
+    if (this._setValueTimeout) {
+        clearTimeout(this._setValueTimeout);
+    }
     this._value = value;
     if (this._componentInitialized) {
         if (this._webview) {
@@ -117,7 +122,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                 this._fromEditor = false;
             } else {
                 // Editor is not loaded yet, try again in half a second
-                setTimeout(() => {
+                this._setValueTimeout = setTimeout(() => {
                     this.value = value;
                 }, 500);
             }
@@ -134,7 +139,7 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
                 this.zone.run(() => this._value = value);
             } else {
               // Editor is not loaded yet, try again in half a second
-              setTimeout(() => {
+              this._setValueTimeout = setTimeout(() => {
                 this.value = value;
               }, 500);
             }


### PR DESCRIPTION
Clears timeouts to prevent the `value` from being set to an outdated value. Fixes #58

#### TODOs

- Add unit tests

#### Test Steps

- [ ] `npm install`
- [ ] `npm run serve`
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `npm pack ./deploy/platform/code-editor/`
- [ ] Within app_center `npm install PATH_TO_TGZ_GENERATED`

