### PR TITLE
perf(monaco): make sure monaco is loaded only once

### DIFF
--- a/src/platform/code-editor/code-editor.component.scss
+++ b/src/platform/code-editor/code-editor.component.scss
@@ -9,3 +9,10 @@
     right: 0;
   }
 }
+
+::ng-deep {
+  // hide this part of monaco so it doesnt add height
+  .monaco-aria-container {
+    display: none;
+  }  
+}

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -11,13 +11,9 @@ const noop: any = () => {
 
 // counter for ids to allow for multiple editors on one page
 let uniqueCounter: number = 0;
-let loadedMonaco: boolean = false;
-let loadPromise: Promise<void>;
 // declare all the built in electron objects
 declare const electron: any;
 declare const monaco: any;
-declare const require: any;
-declare const process: any;
 
 @Component({
   selector: 'td-code-editor',
@@ -659,39 +655,34 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
    */
   ngAfterViewInit(): void {
     if (!this._isElectronApp) {
-        if (loadedMonaco) {
-            // Wait until monaco editor is available
-            this.waitForMonaco().then(() => {
-                this.initMonaco();
-            });
-        } else {
-            loadedMonaco = true;
-            loadPromise = new Promise<void>((resolve: any) => {
-                if (typeof((<any>window).monaco) === 'object') {
-                    resolve();
-                    return;
-                }
-                let onGotAmdLoader: any = () => {
-                    // Load monaco
-                    (<any>window).require.config({ paths: { 'vs': 'assets/monaco/vs' } });
-                    (<any>window).require(['vs/editor/editor.main'], () => {
-                        this.initMonaco();
-                        resolve();
-                    });
-                };
-
-                // Load AMD loader if necessary
-                if (!(<any>window).require) {
-                    let loaderScript: HTMLScriptElement = document.createElement('script');
-                    loaderScript.type = 'text/javascript';
-                    loaderScript.src = 'assets/monaco/vs/loader.js';
-                    loaderScript.addEventListener('load', onGotAmdLoader);
-                    document.body.appendChild(loaderScript);
-                } else {
-                    onGotAmdLoader();
-                }
-            });
+      let interval: any = setInterval(() => {
+        if (typeof((<any>window).monaco) === 'object') {
+          clearInterval(interval);
+          this.initMonaco();
+          return;
         }
+      }, 100);
+      if (!document.getElementById('monaco-loader-script')) {
+        let onGotAmdLoader: any = () => {
+          // Load monaco
+          (<any>window).require.config({ paths: { 'vs': 'assets/monaco/vs' } });
+          (<any>window).require(['vs/editor/editor.main'], () => {
+            // TODO
+          });
+        };
+
+        // Load AMD loader if necessary
+        if (!(<any>window).require) {
+          let loaderScript: HTMLScriptElement = document.createElement('script');
+          loaderScript.id = 'monaco-loader-script';
+          loaderScript.type = 'text/javascript';
+          loaderScript.src = 'assets/monaco/vs/loader.js';
+          loaderScript.addEventListener('load', onGotAmdLoader);
+          document.body.appendChild(loaderScript);
+        } else {
+          onGotAmdLoader();
+        }
+      }
     }
     merge(
       fromEvent(window, 'resize').pipe(
@@ -725,13 +716,6 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
     this._webview ? this._webview.send('dispose') : this._editor.dispose();
     this._destroy.next(true);
     this._destroy.unsubscribe();
-  }
-
-  /**
-   * waitForMonaco method Returns promise that will be fulfilled when monaco is available
-   */
-  waitForMonaco(): Promise<void> {
-    return loadPromise;
   }
 
  /**

--- a/src/platform/code-editor/code-editor.utils.ts
+++ b/src/platform/code-editor/code-editor.utils.ts
@@ -1,0 +1,23 @@
+import { Subject, Observable } from 'rxjs';
+
+/**
+ * Waits until monaco has been loaded so we can reference its global object.
+ */
+export function waitUntilMonacoReady(): Observable<void> {
+  let monacoReady$: Subject<void> = new Subject<void>();
+
+  // create interval to check if monaco has been loaded
+  let interval: any = setInterval(() => {
+    if (isMonacoLoaded()) {
+      // clear interval when monaco has been loaded
+      clearInterval(interval);
+      monacoReady$.next();
+      monacoReady$.complete();
+    }
+  }, 100);
+  return monacoReady$.asObservable();
+}
+
+export function isMonacoLoaded(): boolean {
+  return typeof((<any>window).monaco) === 'object';
+}

--- a/src/platform/code-editor/public-api.ts
+++ b/src/platform/code-editor/public-api.ts
@@ -1,2 +1,3 @@
 export { TdCodeEditorComponent } from './code-editor.component';
 export { CovalentCodeEditorModule } from './code-editor.module';
+export * from './code-editor.utils';


### PR DESCRIPTION
We are going to set an `id` in the script tag that loads monaco so we avoid duplicate load scripts when rendering multiple code editors at the same time.

Also we are going to check if monaco has been loaded via an interval and observable rather than a promise to separate concerns and being able to cancel the observable if needed.

Added also some utility functions to help with that and enable developers hook into them.