### PR TITLE
fix(): make sure editor is instantiated before disposing

### DIFF
--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -722,7 +722,11 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
 
   ngOnDestroy(): void {
     this._changeDetectorRef.detach();
-    this._webview ? this._webview.send('dispose') : this._editor.dispose();
+    if (this._webview) {
+      this._webview.send('dispose');
+    } else if (this._editor) {
+      this._editor.dispose();
+    }
     this._destroy.next(true);
     this._destroy.unsubscribe();
   }


### PR DESCRIPTION
When adding and then removing the editor to quick into the DOM (in case of tdLoading or something like that) sometimes we get an undefined error because its instance hasnt been created by the time we are trying to dispose it.

This PR checks before disposing it if it has been created.