### PR TITLE
*DEPRECATE* feat(bundle): deprecation of bundled monaco version

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,7 +12,7 @@ npm install @covalent/code-editor
       "assets": [
         {
           "glob": "**/*",
-          "input": "node_modules/@covalent/code-editor/assets/monaco",
+          "input": "node_modules/monaco-editor/min",
           "output": "/assets/monaco"
         }
       ],

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -13,6 +13,10 @@ npm install @covalent/code-editor
         {
           "glob": "**/*",
           "input": "node_modules/monaco-editor/min",
+          /**
+           * DEPRECATED and will be removed in 3.0.0
+           * "input": "node_modules/@covalent/code-editor/assets/monaco",
+           */
           "output": "/assets/monaco"
         }
       ],


### PR DESCRIPTION
We will favor the installed `monaco-editor` package instead of having to bundle a fixed version.

This will be done to allow people to update monaco as they see fit.

This PR will change the SETUP information but we will also have to mention this in our CHANGE LOG.